### PR TITLE
Type preview

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
         defaultPackage = pkgs.callPackage ./nix/pzprnode.nix {
           pzprjs = pzprjs.defaultPackage.${system};
         };
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [nodejs];
+        };
       }
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
       "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "pzpr-canvas": "^0.8.2",
-        "source-map-support": "^0.5.17"
+        "pzpr-canvas": "0.8.2",
+        "source-map-support": "^0.5.21"
       },
       "devDependencies": {
         "del-cli": "^4.0.1",
@@ -32,12 +32,12 @@
         "grunt-contrib-concat": "^1.0.1",
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-uglify": "^5.2.1",
-        "grunt-newer": "^1.1.1",
         "mocha": "^10.0.0",
+        "nyc": "^15.1.0",
         "prettier": "^1.19.1"
       },
       "engines": {
-        "node": ">= 5.6.0"
+        "node": ">= 14.0"
       }
     },
     "node_modules/@types/node": {
@@ -73,11 +73,11 @@
         "grunt-contrib-concat": "^1.0.1",
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-uglify": "^5.2.1",
-        "grunt-newer": "^1.1.1",
         "mocha": "^10.0.0",
+        "nyc": "^15.1.0",
         "prettier": "^1.19.1",
-        "pzpr-canvas": "^0.8.2",
-        "source-map-support": "^0.5.17"
+        "pzpr-canvas": "0.8.2",
+        "source-map-support": "^0.5.21"
       }
     },
     "typescript": {


### PR DESCRIPTION
This adds opengraph metadata and preview images for puzzle types, as per #12.

It's quite hacky with the way the sample data is loaded, can fix that down the line if pzprjs exports the sample data a bit more nicely.

This doesn't deal yet with piece banks in statue park.